### PR TITLE
Agregar función de eliminación para submenús

### DIFF
--- a/src/controllers/submenus.controller.js
+++ b/src/controllers/submenus.controller.js
@@ -261,3 +261,44 @@ export const updateSubMenu = async (req, res) => {
       res.status(500).json({ message: "Error al actualizar el submenú" });
     }
   };
+
+
+
+  
+/**
+ * Elimina un submenú específico por su ID de la base de datos.
+ *
+ * @param {Object} req - Objeto de solicitud Express.
+ * @param {Object} res - Objeto de respuesta Express.
+ * @returns {Promise<void>}
+ * @throws {Error} Lanza un error si falla la eliminación.
+ */
+export const deleteSubMenu = async (req, res) => {
+    const subMenuId = req.params.id;
+  
+    try {
+      const place_id = 0;
+      const sequelize = getDatabaseInstance(place_id);
+  
+      // Ejecuta la consulta para eliminar un submenú específico por su ID
+      const [deletedSubMenu, metadata] = await sequelize.query(`
+          DELETE FROM db_prueba.dbo.sub_menu WHERE id_sub_menu = :id;
+        `,
+        {
+          replacements: { id: subMenuId },
+        }
+      );
+  
+      // Verifica si el submenú se eliminó correctamente
+      if (metadata > 0) {
+        // Envía una respuesta de éxito o datos adicionales según sea necesario
+        res.json({ message: "Submenú eliminado exitosamente" });
+      } else {
+        res.status(404).json({ message: "Submenú no encontrado" });
+      }
+    } catch (error) {
+      // Registra el error y envía un estado 500 con una respuesta JSON
+      console.error(error);
+      res.status(500).json({ message: "Error al eliminar el submenú" });
+    }
+  };


### PR DESCRIPTION
Descripción del Commit:
Se ha agregado la función deleteSubMenu, que permite eliminar un submenú específico de la base de datos utilizando su ID. La función ejecuta una consulta DELETE en la tabla db_prueba.dbo.sub_menu con el ID proporcionado en la solicitud Express. Si la eliminación es exitosa (se elimina al menos un registro), se responde con un mensaje indicando que el submenú ha sido eliminado correctamente. En caso de que el submenú no se encuentre (ningún registro eliminado), se responde con un estado 404 y un mensaje indicando que el submenú no fue encontrado. Si ocurre algún error durante la eliminación, se registra la excepción y se responde con un estado 500 y un mensaje indicando que ha habido un error en la eliminación del submenú.